### PR TITLE
Ensure that localStorage logic work if item is not first

### DIFF
--- a/src/app/utils/authenticated.js
+++ b/src/app/utils/authenticated.js
@@ -1,6 +1,6 @@
-
 function requireAuth(nextState, replace) {
-    const data = JSON.parse(localStorage.getItem(localStorage.key(0)));
+    const key = Object.keys(localStorage).find(e => e.match(/firebase:authUser/))
+    const data = JSON.parse(localStorage.getItem(key));
     if (!data.uid) {
         replace({
             pathname: '/login',


### PR DESCRIPTION
I was unsure about this, but locally this section was failing because the relevant key was not first in my localStorage. The correct one was titled something like,
```
firebase:authUser:LKJsdfjksdfsjXXXXXXdfsjdfjsdf8j_NM:[DEFAULT]
``

I'm assuming the 'firebase:authUser' part is standard.