### PR TITLE
changed var to const in utils/firebase.js

### DIFF
--- a/src/app/utils/firebase.js
+++ b/src/app/utils/firebase.js
@@ -5,7 +5,7 @@ export const firebaseApp = firebase.initializeApp(FIREBASE_CONFIG);
 export const firebaseAuth = firebaseApp.auth();
 export const firebaseDb = firebaseApp.database();
 
-var FireBaseTools = {
+const FireBaseTools = {
 
   /**
    * Return an instance of a firebase auth provider based on the provider string.


### PR DESCRIPTION
No reason to use var here, especially since const is used already.